### PR TITLE
Add mobile responsive styles for site header and navigation

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -187,6 +187,19 @@ figcaption {
 .nav a:hover, .nav a.is-active { color: var(--accent); }
 .nav a.is-active::before { color: var(--accent); }
 
+@media (max-width: 36rem) {
+  .site-header__inner {
+    padding: 1.25rem 0 1rem;
+    gap: 0.85rem;
+  }
+  .nav {
+    width: 100%;
+    flex-wrap: wrap;
+    row-gap: 0.5rem;
+    padding-top: 0.25rem;
+  }
+}
+
 main { padding: 2.5rem 0 4rem; }
 
 /* ----- home page ----- */


### PR DESCRIPTION
## Summary
Added responsive design improvements for mobile devices by implementing media query styles for the site header and navigation components on screens 36rem (576px) and below.

## Key Changes
- Added mobile-specific padding adjustments to `.site-header__inner` to reduce vertical spacing (1.25rem 0 1rem) and gap between elements (0.85rem)
- Configured `.nav` to stack responsively on mobile with:
  - Full width layout (`width: 100%`)
  - Flex wrapping enabled (`flex-wrap: wrap`)
  - Reduced row gap between wrapped items (0.5rem)
  - Minor top padding adjustment (0.25rem)

## Implementation Details
The changes use a standard mobile-first breakpoint at `max-width: 36rem` to ensure the navigation and header remain usable and properly spaced on smaller screens. The adjustments maintain visual hierarchy while optimizing space usage on mobile devices.

https://claude.ai/code/session_01LsaitRNMt2rh6zxGMxcJ3q