### PR TITLE
Rename master branch to main in pages workflow trigger

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Build and deploy site
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Update the deploy workflow to trigger on pushes to the renamed
default branch.